### PR TITLE
Correct akpa to ulo as correct

### DIFF
--- a/README
+++ b/README
@@ -50,9 +50,9 @@ commands should work:
 
 ```console
 $ echo "house" | apertium -d . eng-ibo
-#akpa#
+#ụlọ#
 
-$ echo "akpa" | apertium -d . ibo-eng
+$ echo "ụlọ" | apertium -d . ibo-eng
 #house
 ```
 
@@ -60,7 +60,7 @@ After installing somewhere in `$PATH`, you should be able to do e.g.
 
 ```console
 $ echo "house" | apertium eng-ibo
-#akpa#
+#ụlọ#
 ```
 
 Files and data


### PR DESCRIPTION
Correct akpa to ulo as correc
igbo  translation for house in readme file
fixes #2
